### PR TITLE
Add Custom Consul services definition

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,11 @@
 title: Scibian 9 HPC Installation guide
 name: scibian9_hpc_installation_guide
 versions:
+- tag: 1.92
+  date: 2019-09-30
+  status: draft
+  changes:
+  - "Add Custom Consul services definition"
 - tag: 1.91
   date: 2019-06-26
   status: draft

--- a/src/inst/gen_serv_nodes/consul.asc
+++ b/src/inst/gen_serv_nodes/consul.asc
@@ -97,3 +97,5 @@ Finally, check DNS requests on virtual zone are managed by Consul with:
 
 The output must report multiple generic service nodes static IP addresses in
 random order.
+
+To advanced custom consul services definition, please <<_custom_consul_services,go to this section...>>

--- a/src/inst/gen_serv_nodes/consul.asc
+++ b/src/inst/gen_serv_nodes/consul.asc
@@ -98,4 +98,4 @@ Finally, check DNS requests on virtual zone are managed by Consul with:
 The output must report multiple generic service nodes static IP addresses in
 random order.
 
-To advanced custom consul services definition, please <<_custom_consul_services,go to this section...>>
+To advanced custom consul services definition, please go to : <<_custom_consul_services>>

--- a/src/inst/opts.asc
+++ b/src/inst/opts.asc
@@ -24,6 +24,8 @@ include::opts/nfs_ha.asc[]
 
 include::opts/pwmgt.asc[]
 
+include::opts/consul.asc[]
+
 ////
 GLPI/fusioninventory services?
 ////

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -4,7 +4,7 @@ Consul services are defined as hash of hashes hiera named
 `profiles::consul::server::subservices` and defined in file 
 `$ADMIN/puppet-hpc/hieradata/common.yaml`.
 
-For instance find bellow excerpt of two services definition, 
+For instance find below excerpt of two services definitions, 
 `http` and `web-system`, with there associated check parameters:
 
 [source,yaml]

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -1,0 +1,52 @@
+=== Custom Consul services
+
+Consul services check is based on defintion as per file `puppet-hpc/hieradata/common.yaml` extract:
+
+[source,yaml]
+----
+profiles::consul::server::subservices:
+  apt:
+    check:
+      id: 'apt_check'
+      name: 'Local HTTP service check'
+      http: "http://%{::hostname}:%{hiera('apt::proxy_port')}/acng-report.html"
+      interval: '10s'
+      timeout: '1s'
+  tftp:
+    check:
+      id: 'tftpd_check'
+      name: 'Local TFTPD service check'
+      script: '/usr/lib/nagios/plugins/check_procs -c 1: --command=in.tftpd'
+      interval: '30s'
+      timeout: '10s'
+  secret:
+    check:
+      id: 'http_secret_check'
+      name: 'Local HTTP secret check'
+      http: "http://localhost:%{hiera('secret_port')}/"
+      interval: '10s'
+      timeout: '1s'
+  web-boot:
+    check:
+      id: 'http_boot_check'
+      name: 'Local HTTP bootsystem check'
+      http: "http://%{::hostname}:%{hiera('boot_http_port')}/"
+      interval: '10s'
+      timeout: '1s'
+  web-system:
+    check:
+      id: 'http_system_check'
+      name: 'Local HTTP System VHost check'
+      http: "http://localhost:%{hiera('profiles::http::system::port')}/"
+      interval: '10s'
+      timeout: '1s'
+----
+
+Any of these service can be disabled with empty hash definition.
+For example, to disable web-system service, just add to `$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:
+[source,yaml]
+----
+profiles::consul::server::subservices:
+# disable web-system service
+  web-system: {}
+----

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -1,7 +1,11 @@
 === Custom Consul services
 
-Consul services check is based on hash of hashes hiera named `profiles::consul::server::subservices`
-and defined in file `$ADMIN/puppet-hpc/hieradata/common.yaml`:
+Consul services are defined as hash of hashes hiera named 
+`profiles::consul::server::subservices` and defined in file 
+`$ADMIN/puppet-hpc/hieradata/common.yaml`.
+
+For instance find bellow excerpt of two services definition, 
+`http` and `web-system`, with there associated check parameters:
 
 [source,yaml]
 ----
@@ -20,10 +24,10 @@ profiles::consul::server::subservices:
       timeout: '1s'
 ----
 
-This defined two services, `http` and `web-system`, with there associated check parameters.
-
-Services check can then be customized by disabling any service definition with empty hash!
-For example, to disable web-system service, just add to `$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:
+Further services check can be customized by disabling any service definition 
+with empty hash!
+For example, to disable web-system service, just add to 
+`$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:
 
 [source,yaml]
 ----

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -1,7 +1,7 @@
 === Custom Consul services
 
-Consul services check is based on hash of hases hiera named : `profiles::consul::server::subservices` and defined
- in file `$ADMIN/puppet-hpc/hieradata/common.yaml`:
+Consul services check is based on hash of hashes hiera named `profiles::consul::server::subservices`
+and defined in file `$ADMIN/puppet-hpc/hieradata/common.yaml`:
 
 [source,yaml]
 ----
@@ -19,6 +19,8 @@ profiles::consul::server::subservices:
       interval: '10s'
       timeout: '1s'
 ----
+
+This defined two services, `http` and `web-system`, with there associated check parameters.
 
 Services check can then be customized by disabling any service definition with empty hash!
 For example, to disable web-system service, just add to `$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -1,38 +1,16 @@
 === Custom Consul services
 
-Consul services check is based on defintion as per file `puppet-hpc/hieradata/common.yaml` extract:
+Consul services check is based on hash of hases hiera named : `profiles::consul::server::subservices` and defined
+ in file `$ADMIN/puppet-hpc/hieradata/common.yaml`:
 
 [source,yaml]
 ----
 profiles::consul::server::subservices:
-  apt:
+  http:
     check:
-      id: 'apt_check'
+      id: 'http_check'
       name: 'Local HTTP service check'
-      http: "http://%{::hostname}:%{hiera('apt::proxy_port')}/acng-report.html"
-      interval: '10s'
-      timeout: '1s'
-  tftp:
-    check:
-      id: 'tftpd_check'
-      name: 'Local TFTPD service check'
-      script: '/usr/lib/nagios/plugins/check_procs -c 1: --command=in.tftpd'
-      interval: '30s'
-      timeout: '10s'
-  secret:
-    check:
-      id: 'http_secret_check'
-      name: 'Local HTTP secret check'
-      http: "http://localhost:%{hiera('secret_port')}/"
-      interval: '10s'
-      timeout: '1s'
-  web-boot:
-    check:
-      id: 'http_boot_check'
-      name: 'Local HTTP bootsystem check'
-      http: "http://%{::hostname}:%{hiera('boot_http_port')}/"
-      interval: '10s'
-      timeout: '1s'
+      http: 'http://localhost/status'
   web-system:
     check:
       id: 'http_system_check'
@@ -42,7 +20,7 @@ profiles::consul::server::subservices:
       timeout: '1s'
 ----
 
-Any of these service can be disabled with empty hash definition.
+Services check can then be customized by disabling any service definition with empty hash!
 For example, to disable web-system service, just add to `$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:
 
 [source,yaml]

--- a/src/inst/opts/consul.asc
+++ b/src/inst/opts/consul.asc
@@ -44,6 +44,7 @@ profiles::consul::server::subservices:
 
 Any of these service can be disabled with empty hash definition.
 For example, to disable web-system service, just add to `$ADMIN/hpc-privatedata/hieradata/$CLUSTER/cluster.yaml`:
+
 [source,yaml]
 ----
 profiles::consul::server::subservices:


### PR DESCRIPTION
Consul services definition is now hash of hashes,
instead of array of hashes. This way, service can be
easily activated or disabled right now...